### PR TITLE
New display for Critical Edition Objects.

### DIFF
--- a/css/critical_edition_container.css
+++ b/css/critical_edition_container.css
@@ -20,3 +20,34 @@
   margin-left: auto;
   margin-right: auto;
 }
+div.transcriptions-container, div.operations-container, div.edition-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-width: 100px;
+  min-height: 25px;
+}
+div.version-links, div.edition-links {
+  position: absolute;
+  top: 0px;
+}
+div.version-links {
+  left: 0px;
+}
+div.edition-links {
+  right: 0px;
+}
+select.transcription-select {
+  max-width: 200px;
+  margin-top: 4px;
+}
+div.transcription-links, div.operation-links {
+  position: absolute;
+  right: 15px;
+  top: 4px;
+  background-color: #ffffff;
+}
+div.operation-links {
+  left: 0px;
+  width: 180px;
+}

--- a/includes/container_management.inc
+++ b/includes/container_management.inc
@@ -213,67 +213,67 @@ function islandora_critical_edition_management_menu(AbstractObject $object) {
   $output['manage_critical_edition'] = array('#type' => 'vertical_tabs');
 
   $output['manage_critical_edition']['replace_apparatus'] = array(
+    '#id' => 'replace-apparatus',
     '#access' => user_access(ISLANDORA_ADD_DS) && empty($apparatus),
     '#title' => t('Create Apparatus'),
     '#description' => t('Creates blank Critical Apparatus'),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_replace_apparatus', $object),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
   $output['manage_critical_edition']['attach_tei_rdf'] = array(
+    '#id' => 'attach-tei-rdf',
     '#access' => user_access(ISLANDORA_ADD_DS),
     '#title' => t('Associate TEI-RDF Object'),
     '#description' => t('Associate existing TEI-RDF Object from repository.'),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_associate_tei_rdf_form', $object, 'islandora:criticalEditionCModel'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
   $output['manage_critical_edition']['attach_audio'] = array(
+    '#id' => 'attach-audio',
     '#access' => user_access(ISLANDORA_ADD_DS),
     '#title' => t('Associate Audio Object'),
     '#description' => t('Associate existing Audio Object from repository.'),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_associate_audio_form', $object, 'islandora:sp-audioCModel'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
   $output['manage_critical_edition']['attach_video'] = array(
+    '#id' => 'attach-video',
     '#access' => user_access(ISLANDORA_ADD_DS),
     '#title' => t('Associate Video Object'),
     '#description' => t('Associate existing Video Object from repository.'),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_associate_video_form', $object, 'islandora:sp_videoCModel'),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
   $output['manage_critical_edition']['create_vo'] = array(
+    '#id' => 'create-vo',
     '#access' => user_access(ISLANDORA_ADD_DS),
     '#title' => t('Create new Versionable Object'),
     '#description' => t("Create Versionable object and associate it with this Critical Edition."),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_create_versionable_object', $object),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
   $output['manage_critical_edition']['attach_vo'] = array(
+    '#id' => 'attach-vo',
     '#access' => user_access(ISLANDORA_ADD_DS),
     '#title' => t('Associate existing Versionable Object'),
     '#description' => t('Associate existing Versionable Object with this Critical Edition'),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_attach_versionable', $object),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
 
   $output['manage_critical_edition']['mvd'] = array(
+    '#id' => 'mvd',
     '#access' => user_access(ISLANDORA_ADD_DS) && $transcriptions,
     '#title' => t('Create MVD'),
     '#type' => 'fieldset',
     'form' => drupal_get_form('islandora_critical_edition_mvd_form', $object),
-    '#collapsible' => TRUE,
-    '#collapsed' => TRUE,
+    '#group' => 'manage_critical_edition',
   );
   return $output;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -324,3 +324,73 @@ function islandora_critical_edition_create_select_teirdf_object_table(array $obj
     ),
   );
 }
+
+/**
+ * Gets the number of child versionable objects the given object has.
+ *
+ * @param AbstractObject $object
+ *   A critical edition containter object.
+ *
+ * @return int
+ *   The number of versionable objects the given object has.
+ */
+function islandora_critical_edition_number_of_child_versionable_objects(AbstractObject $object) {
+  $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+PREFIX islandora: <http://islandora.ca/ontology/relsext#>
+SELECT DISTINCT ?object FROM <#ri> WHERE {
+ ?object fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+         fedora-model:hasModel <info:fedora/islandora:versionableObjectCModel> .
+}
+EOT;
+  return $object->repository->ri->countQuery($query, 'sparql');
+}
+
+/**
+ * Gets the number of child collation objects the given object has.
+ *
+ * @param AbstractObject $object
+ *   A critical edition containter object.
+ *
+ * @return int
+ *   The number of collation objects the given object has.
+ */
+function islandora_critical_edition_number_of_child_transcriptions(AbstractObject $object) {
+  // Count the number of transcriptions of all verionable objects.
+  $query = <<<EOT
+    PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+    PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+    PREFIX islandora: <http://islandora.ca/ontology/relsext#>
+      SELECT DISTINCT ?transcript FROM <#ri> WHERE {
+        ?object fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+        fedora-model:hasModel <info:fedora/islandora:versionableObjectCModel> .
+        ?transcript fedora-rels-ext:isMemberOf ?object ;
+        fedora-model:hasModel <info:fedora/islandora:transcriptionCModel> .
+      }
+EOT;
+ return $object->repository->ri->countQuery($query, 'sparql');
+}
+
+/**
+ * Gets the number of child collation objects the given object has.
+ *
+ * @param AbstractObject $object
+ *   A critical edition containter object.
+ *
+ * @return int
+ *   The number of collation objects the given object has.
+ */
+function islandora_critical_edition_number_of_child_collation_objects(AbstractObject $object) {
+  // Count the number of collations.
+  $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+PREFIX islandora: <http://islandora.ca/ontology/relsext#>
+SELECT DISTINCT ?object FROM <#ri> WHERE {
+ ?object fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+         fedora-model:hasModel <info:fedora/islandora:mvdCModel> .
+}
+EOT;
+  return $object->repository->ri->countQuery($query, 'sparql');
+}

--- a/includes/versionable_object.inc
+++ b/includes/versionable_object.inc
@@ -35,6 +35,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
   $output = array();
   $output['management_tabs'] = array('#type' => 'vertical_tabs');
   $output['management_tabs']['create_tei_rdf'] = array(
+    '#id' => 'create-tei-rdf',
     '#access' => user_access(ISLANDORA_ADD_DS) && empty($primary_objects),
     '#title' => t('Create TEI-RDF Object'),
     '#description' => t('Create TEI-RDF Object from existing book object'),
@@ -44,6 +45,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
     '#collapsed' => TRUE,
   );
   $output['management_tabs']['attach_tei_rdf'] = array(
+    '#id' => 'attach-tei-rdf',
     '#access' => user_access(ISLANDORA_ADD_DS) && empty($primary_objects),
     '#title' => t('Associate TEI-RDF Object'),
     '#description' => t('Associate existing TEI-RDF Object from repository'),
@@ -53,6 +55,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
     '#collapsed' => TRUE,
   );
   $output['management_tabs']['attach_partial_tei_rdf'] = array(
+    '#id' => 'attach-partial-tei-rdf',
     '#access' => user_access(ISLANDORA_ADD_DS) && empty($primary_objects),
     '#title' => t('Create TEI-RDF Object from existing object'),
     '#description' => t('Create new RDF-TEI object as a full or partial subset on an existing object.'),
@@ -63,6 +66,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
   );
 
   $output['management_tabs']['add_transcription'] = array(
+    '#id' => 'add-transcription',
     '#access' => user_access(ISLANDORA_ADD_DS),
     '#title' => t('Create Transcription'),
     '#type' => 'fieldset',
@@ -71,6 +75,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
     '#collapsed' => TRUE,
   );
   $output['management_tabs']['manage_transcription'] = array(
+    '#id' => 'manage-transcription',
     '#access' => user_access(ISLANDORA_ADD_DS) && $transcriptions,
     '#title' => t('Manage Transcriptions'),
     '#type' => 'fieldset',
@@ -80,6 +85,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
   );
 
   $output['management_tabs']['delete_tei_rdf'] = array(
+    '#id' => 'delete-tei-rdf',
     '#access' => user_access(ISLANDORA_ADD_DS) && $tei_rdf,
     '#title' => t('Disassociate TEI-RDF Object'),
     '#type' => 'fieldset',
@@ -88,6 +94,7 @@ function islandora_versionable_object_management_menu(AbstractObject $object) {
     '#collapsed' => TRUE,
   );
   $output['management_tabs']['update_datastreams'] = array(
+    '#id' => 'update-datastreams',
     '#access' => user_access(ISLANDORA_ADD_DS) && $tei_rdf,
     '#title' => t('Update Consolidated TEI'),
     '#type' => 'fieldset',

--- a/islandora_critical_edition_advanced.module
+++ b/islandora_critical_edition_advanced.module
@@ -112,7 +112,59 @@ function islandora_critical_edition_advanced_theme($existing, $type, $theme, $pa
       'file' => 'theme/theme.inc',
       'template' => 'theme/islandora_critical_edition_container',
       'pattern' => 'islandora_critical_edition_container__',
-      'variables' => array('islandora_object' => NULL),
+      'variables' => array('object' => NULL),
+    ),
+    'islandora_critical_edition_container_table' => array(
+      'file' => 'theme/theme.inc',
+      'variables' => array(
+        'object' => NULL,
+        'title' => '',
+        'header' => array(),
+        'rows' => array(),
+        'offset' => 0,
+        'limit' => 25,
+        'total' => 0,
+        'pager' => array(
+          'element' => 0,
+          'tags' => array('<<', '<', '', '>', '>>'),
+          'quantity' => 3,
+        ),
+      ),
+    ),
+    'islandora_critical_edition_container_versions_table' => array(
+      'file' => 'theme/theme.inc',
+      'variables' => array(
+        'object' => NULL,
+        'limit' => 25,
+        'columns' => array(
+          'version_name' => TRUE,
+          'source_name' => TRUE,
+          'transcriptions' => TRUE,
+          'operations' => TRUE,
+        ),
+        'pager' => array(
+          'element' => 0,
+          'tags' => array('<<', '<', '', '>', '>>'),
+          'quantity' => 3,
+        ),
+      ),
+    ),
+    'islandora_critical_edition_container_collations_table' => array(
+      'file' => 'theme/theme.inc',
+      'variables' => array(
+        'object' => NULL,
+        'limit' => 25,
+        'columns' => array(
+          'collation_name' => TRUE,
+          'transcriptions' => TRUE,
+          'operations' => TRUE,
+        ),
+        'pager' => array(
+          'element' => 1,
+          'tags' => array('<<', '<', '', '>', '>>'),
+          'quantity' => 3,
+        ),
+      ),
     ),
     'islandora_versionable_object' => array(
       'file' => 'theme/theme.inc',
@@ -145,7 +197,7 @@ function islandora_critical_edition_advanced_theme($existing, $type, $theme, $pa
  * Implements hook_CMODEL_PID_islandora_view_object().
  */
 function islandora_critical_edition_islandora_criticalEditionContainerCModel_islandora_view_object($object, $page_number, $page_size) {
-  $output = theme('islandora_critical_edition_container', array('islandora_object' => $object));
+  $output = theme('islandora_critical_edition_container', array('object' => $object));
   return array('' => $output);
 }
 

--- a/js/select_transcription.js
+++ b/js/select_transcription.js
@@ -1,0 +1,31 @@
+(function($) {
+  "use strict";
+
+  /**
+   * @file
+   */
+  Drupal.behaviors.selectTranscription = {
+    attach: function(context, settings) {
+      // Bind Ajax behaviors to all items showing the class.
+      $('.transcription-select').once(function () {
+        $(this).change(function() {
+          var pid = $(this).val();
+          // This is hard coded for now, as we need to save time, sorry.
+          var paths = {
+            "view": "/islandora/object/" + pid,
+            "edit": "/islandora/transcription/edit/" + pid,
+            "delete": "/islandora/object/" + pid + "/delete",
+          };
+          $(this).parents('.transcriptions-container').find('li').each(function() {
+            var action = undefined;
+            for(action in paths) {
+              if ($(this).hasClass(action)) {
+                $('a', this).attr('href', paths[action]);
+              }
+            }
+          });
+        });
+      });
+    }
+  };
+})(jQuery);

--- a/theme/islandora_critical_edition_container.tpl.php
+++ b/theme/islandora_critical_edition_container.tpl.php
@@ -1,39 +1,15 @@
 <?php
 /**
  * @file
- * islandora_critical_edition_container.tpl.php
+ * Template for the islandora critical edition object display.
  */
-module_load_include('inc', 'islandora', 'includes/breadcrumb');
-$object = $variables['islandora_object'];
-$versionable_objects = array_merge($variables['apparatus'], $variables['versionable_objects']);
-drupal_set_breadcrumb(islandora_get_breadcrumbs($object));
-drupal_set_title($object->label);
+// @todo Render out the critical apparatus object view.
 ?>
-
-<div class="islandora_versionable_objects">
-  <?php foreach ($versionable_objects as $versionable): ?>
-    <div class="versionable_object">
-      <?php
-      $versionable_object = islandora_object_load($versionable);
-      $object_url = 'islandora/object/' . $versionable;
-      $title = $versionable_object->label;
-      $image_variables = array(
-        'path' => "$object_url/datastream/TN/view",
-        'alt' => $title,
-        'title' => $title,
-        'attributes' => array('class' => 'versionable_object'),
-      );
-
-      $thumbnail_img = theme('image', $image_variables);
-      $link = l($thumbnail_img, $object_url, array(
-        'html' => TRUE,
-        'attributes' => array('title' => $title, 'alt' => $title)));
-      $caption = l($title, $object_url);
-      ?>
-      <dl class="islandora_critical_edition_object">
-        <dt class="islandora_critical_edition_object_thumb"><?php print $link; ?></dt>
-        <dd class="islandora_critical_edition_object_caption"><?php print $caption; ?></dd>
-      </dl>
-    </div>
-  <?php endforeach; ?>
+<?php print drupal_render($apparatus); ?>
+<div class="edition-container">
+  <?php print drupal_render($version_actions); ?>
+  <?php print drupal_render($edition_actions); ?>
 </div>
+<?php print drupal_render($versions); ?>
+<?php print drupal_render($collation_actions); ?>
+<?php print drupal_render($collations); ?>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -6,9 +6,9 @@
  */
 
 /**
- * Implements hook_preprocess_islandora_critical_edition().
+ * Implements hook_preprocess_theme().
  */
-function islandora_critical_edition_preprocess_islandora_critical_apparatus(&$variables) {
+function islandora_critical_edition_preprocess_islandora_critical_apparatus(array &$variables) {
   islandora_critical_edition_advanced_prep_tabs();
   module_load_include('inc', 'islandora_critical_edition_advanced', 'includes/utilities');
   // @TODO add string translation
@@ -16,22 +16,9 @@ function islandora_critical_edition_preprocess_islandora_critical_apparatus(&$va
 }
 
 /**
- * Implements hook_preprocess_islandora_critical_edition_container().
+ * Implements hook_preprocess_theme().
  */
-function islandora_critical_edition_preprocess_islandora_critical_edition_container(&$variables) {
-  module_load_include('inc', 'islandora_critical_edition_advanced', 'includes/utilities');
-  $path = drupal_get_path('module', 'islandora_critical_edition_advanced');
-  drupal_add_css("$path/css/critical_edition_container.css");
-  module_load_include('inc', 'islandora_critical_edition', 'includes/utilities');
-  $members = islandora_critical_edition_get_members($variables['islandora_object']->id);
-  $variables['apparatus'] = array_keys($members, 'islandora:criticalApparatusCModel');
-  $variables['versionable_objects'] = array_keys($members, 'islandora:versionableObjectCModel');
-}
-
-/**
- * Implements hook_preprocess_islandora_critical_edition_container().
- */
-function islandora_critical_edition_preprocess_islandora_transcription_object(&$variables) {
+function islandora_critical_edition_preprocess_islandora_transcription_object(array &$variables) {
   islandora_critical_edition_advanced_prep_tabs();
   $multiple = FALSE;
   if (isset($variables['transcriptions']) && count($variables['transcriptions']) > 1) {
@@ -41,9 +28,9 @@ function islandora_critical_edition_preprocess_islandora_transcription_object(&$
 }
 
 /**
- * Implements hook_preprocess_islandora_critical_edition_container().
+ * Implements hook_preprocess_theme().
  */
-function islandora_critical_edition_preprocess_islandora_critical_media_object(&$variables) {
+function islandora_critical_edition_preprocess_islandora_critical_media_object(array &$variables) {
   global $base_url;
   module_load_include('inc', 'islandora_critical_edition', 'theme/theme');
   module_load_include('inc', 'islandora_critical_edition', 'includes/utilities');
@@ -158,4 +145,641 @@ function islandora_critical_edition_advanced_prep_tabs() {
   $critical_edition_advanced_module_path = drupal_get_path('module', 'islandora_critical_edition_advanced');
   drupal_add_js($critical_edition_advanced_module_path . "/js/activate_tabs.js");
   drupal_add_css("$critical_edition_advanced_module_path/css/jquery-ui.css");
+}
+
+/**
+ * Implements hook_preprocess_theme().
+ *
+ * This function is resposible for fetching the required data to render the
+ * critical edition object.
+ */
+function islandora_critical_edition_preprocess_islandora_critical_edition_container(array &$variables) {
+  $module_path = drupal_get_path('module', 'islandora_critical_edition_advanced');
+  drupal_add_css("$module_path/css/critical_edition_container.css");
+  // For now we are using views/ctools to style our drop downs if they are not
+  // enabled plain links will be rendered.
+  $views_module_path = drupal_get_path('module', 'views');
+  drupal_add_css("$views_module_path/css/views-admin.ctools.css");
+  drupal_add_css("$views_module_path/css/views-admin.seven.css");
+
+  $object = $variables['object'];
+  $variables['apparatus'] = array('#markup' => '<div><strong>Apparatus Goes Here</strong></div>');
+  $variables['edition_actions'] = islandora_critical_edition_container_editor_links($object);
+  $variables['version_actions'] = islandora_critical_edition_container_version_links($object);
+  $variables['collation_actions'] = islandora_critical_edition_container_collation_links($object);
+  $variables['versions'] = array(
+    '#theme' => 'islandora_critical_edition_container_versions_table',
+    '#object' => $object,
+  );
+  $variables['collations'] = array(
+    '#theme' => 'islandora_critical_edition_container_collations_table',
+    '#object' => $object,
+  );
+}
+
+/**
+ * Get the definition for the editor links.
+ */
+function islandora_critical_edition_container_editor_links(AbstractObject $object) {
+  $permissions = array(
+    'edit_metadata' => user_access(ISLANDORA_METADATA_EDIT),
+    'edit_permissions' => function_exists('islandora_xacml_editor_access') && islandora_xacml_editor_access($object),
+    'workbench' => user_access('use islandora_bookmark'),
+  );
+  $links = array(
+    'edit_metadata' => array(
+      'title' => t('Edit Edition Metadata'),
+      'href' => "islandora/object/{$object->id}/datastream/MODS/edit",
+    ),
+    'edit_permissions' => array(
+      'title' => t('Edit Permissions'),
+      'href' => "islandora/object/{$object->id}/manage/xacml",
+    ),
+    'workbench' => array(
+      'title' => t('Add to Workbench'),
+      'href' => '',
+      'external' => TRUE,
+      'fragment' => 'not_implemented',
+    ),
+  );
+  return array(
+    '#theme' => 'links__ctools_dropbutton',
+    '#class' => array('edition-links'),
+    '#links' => array_intersect_key($links, array_filter($permissions)),
+  );
+}
+
+/**
+ * Get the definition for the version links.
+ */
+function islandora_critical_edition_container_version_links(AbstractObject $object) {
+  $permissions = array(
+    'add' => user_access(ISLANDORA_INGEST),
+    'import' => user_access(ISLANDORA_INGEST),
+  );
+  $links = array(
+    'add' => array(
+      'title' => t('Add New Version'),
+      'href' => "islandora/object/{$object->id}/manage/edition_container",
+      'fragment' => 'create-vo',
+    ),
+    'import' => array(
+      'title' => t('Import Version'),
+      'href' => "islandora/object/{$object->id}/manage/edition_container",
+      'fragment' => 'attach-vo',
+    ),
+  );
+  return array(
+    '#theme' => 'links__ctools_dropbutton',
+    '#class' => array('version-links'),
+    '#links' => array_intersect_key($links, array_filter($permissions)),
+  );
+}
+
+/**
+ * Get the definition for the collation links.
+ */
+function islandora_critical_edition_container_collation_links(AbstractObject $object) {
+  module_load_include('inc', 'islandora_critical_edition_advanced', 'includes/utilities');
+  $links = array(
+    array(
+      'title' => t('Add New Collation'),
+      'href' => "islandora/object/{$object->id}/manage/edition_container",
+      'fragment' => 'mvd',
+    ),
+  );
+  $num_transcriptions = islandora_critical_edition_number_of_child_transcriptions($object);
+  return array(
+    '#theme' => 'links__ctools_dropbutton',
+    '#links' => (user_access('edit mvds') && $num_transcriptions >= 2) ? $links : array(),
+  );
+}
+
+/**
+ * Implements theme_hook().
+ *
+ * Renders out the table for display in the critical edition container.
+ */
+function theme_islandora_critical_edition_container_table(array &$variables) {
+  module_load_include('inc', 'islandora_critical_edition_advanced', 'includes/utilities');
+  // Create local variables.
+  extract(array_intersect_key($variables, drupal_map_assoc(array(
+          'title', 'header', 'rows', 'offset', 'limit', 'total', 'pager'))));
+  // Render the table.
+  $element = array(
+    '#type' => 'fieldset',
+    '#title' => t('@title (@start-@end of @total)', array(
+                '@title' => $title,
+                '@start' => $offset,
+                '@end' => min($offset + $limit, $total),
+                '@total' => $total,
+              )),
+    'table' => array(
+      '#theme' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+    ),
+    'pager' => array(
+      '#theme' => 'pager',
+      '#tags' => $pager['tags'],
+      '#element' => $pager['element'],
+      '#quantity' => $pager['quantity'],
+    ),
+  );
+  return drupal_render($element);
+}
+
+/**
+ * Implements theme_hook().
+ *
+ * For the versions table in the critical edition container display.
+ */
+function theme_islandora_critical_edition_container_versions_table(array &$variables) {
+  module_load_include('inc', 'islandora_critical_edition_advanced', 'includes/utilities');
+  // Create local variables.
+  extract(array_intersect_key($variables, drupal_map_assoc(array(
+          'object', 'limit', 'pager', 'columns'))));
+  // Build Header.
+  $headers = array(
+    'version_name' => array('data' => t('Version Name'), 'field' => 'version_name'),
+    'source_name' => array('data' => t('Source Name')),
+    'transcriptions' => array('data' => t('Transcriptions')),
+    'operations' => array('data' => t('Operations')),
+  );
+  // Operations may be hidden if the user doesn't have permission for any.
+  $permissions = islandora_critical_edition_container_versions_table_operations_permissions();
+  $columns['operations'] = isset($columns['operations']) && $columns['operations'] && count(array_filter($permissions));
+  $headers = array_intersect_key($headers, array_filter($columns));
+  // Init Pager.
+  $total = islandora_critical_edition_number_of_child_versionable_objects($object);
+  $page = pager_default_initialize($total, $limit, $pager['element']);
+  $offset = $page * $limit;
+  // Build Rows.
+  $rows = array();
+  $versions = islandora_critical_edition_container_versions_table_data($object, tablesort_get_sort($headers), $offset, $limit);
+  foreach ($versions as $pid => $version) {
+    $source = $version['source'];
+    $cells = array(
+      'version_name' => array(
+        '#markup' => l($version['label'], "islandora/object/{$pid}",
+                   array('attributes' => array('title' => $version['label']))),
+      ),
+      'source_name' => array(
+        '#markup' => l($source->label, "islandora/object/{$source->id}",
+                   array('attributes' => array('title' => $source->label))),
+      ),
+      'transcriptions' => islandora_critical_edition_container_table_transcriptions_cell($pid, $version['transcriptions']),
+      'operations' => islandora_critical_edition_container_versions_table_operations_cell($pid, $version),
+    );
+    // Only include cells which have headers.
+    $cells = array_intersect_key($cells, $headers);
+    $cells = array_map('drupal_render', $cells);
+    foreach ($cells as $name => $data) {
+      $rows[$pid][$name] = array('data' => $data, 'class' => $name);
+    }
+  }
+  return theme('islandora_critical_edition_container_table', array(
+      'title' => t('Versions'),
+      'header' => $headers,
+      'rows' => $rows,
+      'limit' => $limit,
+      'offset' => $offset,
+      'total' => $total,
+      'pager' => $pager,
+    ));
+}
+
+/**
+ * Gets all the required data for populating the Versions table.
+ *
+ * For the versions table in the critical edition container display.
+ *
+ * @param AbstractObject $object
+ *   The critical edition containter object.
+ * @param string $sort
+ *   Either 'DESC' or 'ASC'.
+ * @param int $offset
+ *   The offset from which to return the version table data.
+ * @param int $limit
+ *   The limit on the number of versions returned.
+ *
+ * @return array
+ *   An associative array containing relevent data for building the versions
+ *   display table.
+ */
+function islandora_critical_edition_container_versions_table_data(AbstractObject $object, $sort = 'DESC', $offset = 0, $limit = 25) {
+  // Sort must be uppercase in SPARQL.
+  $sort = strtoupper($sort);
+  $versions = array();
+  // Get the versions and their sources between offset and limit.
+  $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+PREFIX islandora: <http://islandora.ca/ontology/relsext#>
+SELECT DISTINCT ?object ?label ?source FROM <#ri> WHERE {
+ ?object fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+         fedora-model:hasModel <info:fedora/islandora:versionableObjectCModel> .
+ ?x fedora-rels-ext:isMemberOf ?object ;
+    fedora-model:hasModel <info:fedora/islandora:criticalEditionCModel> ;
+    islandora:isCriticalEditionOf ?source .
+ OPTIONAL { ?object fedora-model:label  ?label. }
+}
+ORDER BY $sort(?label)
+OFFSET $offset
+LIMIT $limit
+EOT;
+  // Do a query for all transcripts.
+  $results = $object->repository->ri->sparqlQuery($query, $limit);
+  foreach ($results as $result) {
+    $pid = $result['object']['value'];
+    $versions[$pid] = array(
+      'label' => $result['label']['value'],
+      // Unfortunately we can't get the source title as it is stored as literal
+      // value in the resource index so we must get the object.
+      'source' => islandora_object_load($result['source']['value']),
+      'teirdf' => array(),
+      'transcriptions' => array(),
+    );
+  }
+  // Do a query for all transcripts and TEI-RDF objects we require.
+  $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+SELECT DISTINCT ?version ?child ?child_label ?content_model FROM <#ri> WHERE {
+ ?version fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+         fedora-model:hasModel <info:fedora/islandora:versionableObjectCModel> .
+ ?child fedora-rels-ext:isMemberOf ?version ;
+        fedora-model:hasModel ?content_model .
+ OPTIONAL {
+  ?child  fedora-model:label ?child_label .
+ }
+ FILTER (?content_model != <info:fedora/fedora-system:FedoraObject-3.0>)
+}
+EOT;
+  // Add the transcription and TEI-RDF objects info to the versions array.
+  $results = $object->repository->ri->sparqlQuery($query, 'unlimited');
+  foreach ($results as $result) {
+    $pid = $result['version']['value'];
+    if (!isset($versions[$pid])) {
+      continue;
+    }
+    $version = &$versions[$pid];
+    $child = $result['child']['value'];
+    $child_label = $result['child_label']['value'];
+    switch ($result['content_model']['value']) {
+      case 'islandora:criticalEditionCModel':
+        $version['teirdf'] = array(
+          'pid' => $child,
+          'label' => $child_label,
+        );
+        break;
+
+      case 'islandora:transcriptionCModel':
+        $version['transcriptions'][$child] = $child_label;
+        break;
+    }
+  }
+  return $versions;
+}
+
+/**
+ * Gets the permissions for all the version operations.
+ *
+ * @return array
+ *   An associative array of boolean values indicating the user can perform the
+ *   action.
+ *   - partial: Create Partial versions from an existing version.
+ *   - consolidate: Consolitate the TEI-RDF associated with a version.
+ *   - edit: Edit the version metadata.
+ *   - delete: Purge the version and it's children.
+ */
+function islandora_critical_edition_container_versions_table_operations_permissions() {
+  return array(
+    'partial' => user_access(ISLANDORA_INGEST),
+    'consolidate' => user_access(ISLANDORA_ADD_DS),
+    'edit' => user_access(ISLANDORA_METADATA_EDIT),
+    'delete' => user_access(ISLANDORA_PURGE),
+  );
+}
+
+/**
+ * Generates the transciptions cell for the given version's transcriptions.
+ *
+ * @param string $version
+ *   The PID of the versionable object the transcriptions belong to.
+ * @param array $transcriptions
+ *   An associative array where the keys are the pids of the transcriptions and
+ *   the values are the object's labels.
+ * @param array $links
+ *   The set of links to limit the display to, if none are provided all will be
+ *   shown.
+ *
+ * @return array
+ *   A renderable array containing the links the user has access to.
+ */
+function islandora_critical_edition_container_table_transcriptions_cell($version, array $transcriptions, array $links = array()) {
+  $module_path = drupal_get_path('module', 'islandora_critical_edition_advanced');
+  drupal_add_js("$module_path/js/select_transcription.js");
+  $permissions = array(
+    // Assuming we can always view if we got to this point.
+    'view' => TRUE,
+    'add' => user_access(ISLANDORA_INGEST),
+    'edit' => user_access(ISLANDORA_METADATA_EDIT),
+    'delete' => user_access(ISLANDORA_PURGE),
+  );
+  // Limit links to those provided.
+  if (!empty($links)) {
+    $permissions = array_intersect_key($permissions, drupal_map_assoc($links));
+  }
+  reset($transcriptions);
+  $transcription = key($transcriptions);
+  $links = array(
+    'view' => array(
+      'title' => t('View'),
+      'href' => "islandora/object/{$transcription}",
+      'attributes' => array('title' => t('View the selected Transcript')),
+    ),
+    'add' => array(
+      'title' => t('Add'),
+      'href' => "islandora/object/{$version}/manage/versionable_object",
+      'fragment' => 'add-transcription',
+      'attributes' => array('title' => t('Add a new Transcript')),
+    ),
+    'edit' => array(
+      'title' => t('Edit'),
+      'href' => "islandora/transcription/edit/{$transcription}",
+      'attributes' => array('title' => t('Edit the selected Transcript')),
+    ),
+    'delete' => array(
+      'title' => t('Delete'),
+      'href' => "islandora/object/{$transcription}/delete",
+      'attributes' => array('title' => t('Permanently delete the selected Transcript')),
+    ),
+  );
+  // We can only add if there are no transcriptions.
+  if (count($transcriptions) == 0 && isset($permissions['add']) && $permissions['add']) {
+    return array(
+      '#theme' => 'links__ctools_dropbutton',
+      '#links' => array($links['add']),
+    );
+  }
+  elseif (count($transcriptions) > 0) {
+    return array(
+      '#prefix' => '<div class="transcriptions-container">',
+      '#suffix' => '</div>',
+      'select' => array(
+        '#type' => 'select',
+        '#options' => $transcriptions,
+        '#attributes' => array(
+          'class' => array('transcription-select'),
+        ),
+      ),
+      'links' => array(
+        '#theme' => 'links__ctools_dropbutton',
+        // Only display links the user has access to.
+        '#links' => array_intersect_key($links, array_filter($permissions)),
+        '#class' => array('transcription-links'),
+      ),
+    );
+  }
+  else {
+    return NULL;
+  }
+}
+
+/**
+ * Generates the operations cell for the given version.
+ *
+ * @param string $pid
+ *   The PID of the version.
+ * @param array $version
+ *   An associative array where the keys are properites of the verions and its
+ *   children.
+ *
+ * @return array
+ *   A renderable array containing the links the user has access to.
+ */
+function islandora_critical_edition_container_versions_table_operations_cell($pid, array $version) {
+  $permissions = islandora_critical_edition_container_versions_table_operations_permissions();
+  // If we can't render any links skip the rest of the logic.
+  if (count(array_filter($permissions)) == 0) {
+    return NULL;
+  }
+  $links = array(
+    'partial' => array(
+      'title' => t('Create Partial Version'),
+      'href' => '',
+      'external' => TRUE,
+      'fragment' => 'not_implemented',
+    ),
+    'consolidate' => array(
+      'title' => t('Consolidate TEI'),
+      'href' => "islandora/object/{$pid}/manage/versionable_object",
+      'fragment' => 'update-datastreams',
+    ),
+    'edit' => array(
+      'title' => t('Edit'),
+      'href' => "islandora/object/{$pid}/datastream/MODS/edit",
+    ),
+    'delete' => array(
+      'title' => t('Delete'),
+      'href' => "islandora/object/{$pid}/delete",
+    ),
+  );
+  return array(
+    '#prefix' => '<div class="operations-container">',
+    '#suffix' => '</div>',
+    '#theme' => 'links__ctools_dropbutton',
+    // Only display links the user has access to.
+    '#links' => array_intersect_key($links, array_filter($permissions)),
+    '#class' => array('operation-links'),
+  );
+}
+
+/**
+ * Implements theme_hook().
+ *
+ * For the versions table in the critical edition container display.
+ */
+function theme_islandora_critical_edition_container_collations_table(array &$variables) {
+  module_load_include('inc', 'islandora_critical_edition_advanced', 'includes/utilities');
+  // Create local variables.
+  extract(array_intersect_key($variables, drupal_map_assoc(array(
+          'object', 'limit', 'pager', 'columns'))));
+  // Build Header.
+  $headers = array(
+    'collation_name' => array('data' => t('Collation Name'), 'field' => 'collation_name'),
+    'transcriptions' => array('data' => t('Transcriptions')),
+    'operations' => array('data' => t('Operations')),
+  );
+  // Operations may be hidden if the user doesn't have permission for any.
+  $permissions = islandora_critical_edition_container_collation_table_operations_permissions();
+  $columns['operations'] = isset($columns['operations']) && $columns['operations'] && count(array_filter($permissions));
+  $headers = array_intersect_key($headers, array_filter($columns));
+  // Init Pager.
+  $total = islandora_critical_edition_number_of_child_versionable_objects($object);
+  $page = pager_default_initialize($total, $limit, $pager['element']);
+  $offset = $page * $limit;
+  // Build Rows.
+  $rows = array();
+  $collations = islandora_critical_edition_container_collation_table_data($object, tablesort_get_sort($headers), $offset, $limit);
+  foreach ($collations as $pid => $collation) {
+    $cells = array(
+      'collation_name' => array(
+        '#markup' => l($collation['label'], "islandora/object/{$pid}",
+                   array('attributes' => array('title' => $collation['label']))),
+      ),
+      'transcriptions' => islandora_critical_edition_container_table_transcriptions_cell($pid, $collation['transcriptions'], array('edit')),
+      'operations' => islandora_critical_edition_container_collation_table_operations_cell($pid, $collation['transcriptions']),
+    );
+    // Only include cells which have headers.
+    $cells = array_intersect_key($cells, $headers);
+    $cells = array_map('drupal_render', $cells);
+    foreach ($cells as $name => $data) {
+      $rows[$pid][$name] = array('data' => $data, 'class' => $name);
+    }
+  }
+  return theme('islandora_critical_edition_container_table', array(
+      'title' => t('Collations'),
+      'header' => $headers,
+      'rows' => $rows,
+      'limit' => $limit,
+      'offset' => $offset,
+      'total' => $total,
+      'pager' => $pager,
+    ));
+}
+
+/**
+ * Gets all the required data for populating the collation table.
+ *
+ * For the versions table in the critical edition container display.
+ *
+ * @param AbstractObject $object
+ *   The critical edition containter object.
+ * @param string $sort
+ *   Either 'DESC' or 'ASC'.
+ * @param int $offset
+ *   The offset from which to return the version table data.
+ * @param int $limit
+ *   The limit on the number of versions returned.
+ *
+ * @return array
+ *   An associative array containing relevent data for building the collation
+ *   display table.
+ */
+function islandora_critical_edition_container_collation_table_data(AbstractObject $object, $sort = 'DESC', $offset = 0, $limit = 25) {
+  // Sort must be uppercase in SPARQL.
+  $sort = strtoupper($sort);
+  // Do a query for all collations we require.
+  $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+PREFIX islandora: <http://islandora.ca/ontology/relsext#>
+SELECT DISTINCT ?object ?label FROM <#ri> WHERE {
+ ?object fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+         fedora-model:hasModel <info:fedora/islandora:mvdCModel> .
+ OPTIONAL { ?object fedora-model:label  ?label. }
+}
+ORDER BY $sort(?label)
+OFFSET $offset
+LIMIT $limit
+EOT;
+  $collations = array();
+  $results = $object->repository->ri->sparqlQuery($query, $limit);
+  foreach ($results as $result) {
+    $pid = $result['object']['value'];
+    $collations[$pid] = array(
+      'label' => $result['label']['value'],
+      'transcriptions' => array(),
+    );
+  }
+  // Add the transcription to the collation array.
+  $query = <<<EOT
+PREFIX fedora-rels-ext: <info:fedora/fedora-system:def/relations-external#>
+PREFIX fedora-model: <info:fedora/fedora-system:def/model#>
+SELECT DISTINCT ?collation ?transcription ?transcription_label FROM <#ri> WHERE {
+ ?collation fedora-rels-ext:isMemberOf <info:fedora/$object->id> ;
+            fedora-model:hasModel <info:fedora/islandora:mvdCModel> .
+ ?transcription fedora-rels-ext:isPartOf ?collation ;
+                fedora-model:hasModel <info:fedora/islandora:transcriptionCModel> .
+ OPTIONAL { ?transcription fedora-model:label ?transcription_label . }
+}
+EOT;
+  // Add the transcription and TEI-RDF objects info to the versions array.
+  $results = $object->repository->ri->sparqlQuery($query, 'unlimited');
+  foreach ($results as $result) {
+    $collation = $result['collation']['value'];
+    $transcription = $result['transcription']['value'];
+    $collations[$pid]['transcriptions'][$transcription] = $result['transcription_label']['value'];
+  }
+  return $collations;
+}
+
+/**
+ * Generates the operations cell for the given collation.
+ *
+ * @param string $collation
+ *   The PID of the collation.
+ *
+ * @return array
+ *   A renderable array containing the links the user has access to.
+ */
+function islandora_critical_edition_container_collation_table_operations_cell($collation, array $transcriptions) {
+  $permissions = islandora_critical_edition_container_collation_table_operations_permissions();
+  // If we can't render any links skip the rest of the logic.
+  if (count(array_filter($permissions)) == 0) {
+    return NULL;
+  }
+  $links = array(
+    'refresh' => array(
+      'title' => t('Refresh'),
+      'href' => '',
+      'external' => TRUE,
+      'fragment' => 'not_implemented',
+    ),
+    'compare' => array(
+      'title' => t('Compare'),
+      'href' => '',
+      'external' => TRUE,
+      'fragment' => 'not_implemented',
+    ),
+    'table_view' => array(
+      'title' => t('Table'),
+      'href' => '',
+      'external' => TRUE,
+      'fragment' => 'not_implemented',
+    ),
+    'delete' => array(
+      'title' => t('Delete'),
+      'href' => '',
+      'external' => TRUE,
+      'fragment' => 'not_implemented',
+    ),
+  );
+  return array(
+    '#theme' => 'links__ctools_dropbutton',
+    '#prefix' => '<div class="operations-container">',
+    '#suffix' => '</div>',
+    '#theme' => 'links__ctools_dropbutton',
+    // Only display links the user has access to.
+    '#links' => array_intersect_key($links, array_filter($permissions)),
+    '#class' => array('operation-links'),
+  );
+}
+
+/**
+ * Gets the permissions for all the collation operations.
+ *
+ * @return array
+ *   An associative array of boolean values indicating the user can perform the
+ *   action.
+ */
+function islandora_critical_edition_container_collation_table_operations_permissions() {
+  return array(
+    'refresh' => user_access('edit mvds'),
+    'compare' => user_access('view collation tools'),
+    'table_view' => user_access('view collation tools'),
+    'delete' => user_access(ISLANDORA_PURGE),
+  );
 }


### PR DESCRIPTION
Now displays two tables.
One for paging though all the versions and manipulating them and their children.
One for paging though all the collations and manipulating their transcripts.

Manage tab's for versionable object's and critical editions such that we can
link to specific vertical tabs.

Now the module has soft dependancies on Views/cTools for display of links.
